### PR TITLE
add lat and long to user

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -242,4 +243,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   2.2.16
+   2.2.17

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,9 +3,7 @@ class Api::V1::UsersController < ApplicationController
   def create
     user = User.new(user_params)
     if user.save
-      user_data = MapFacade.return_data(user)
-      trucks = user_data[:trucks]
-      render json: UserSerializer.new(user_data), status: 201
+      render json: UserSerializer.new(user), status: 201
     else
       render json: {data: { error: "Please make sure all fields are filled in before registering. If error persists after filling out fields, username already exists."}}, status: 400
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -9,10 +9,23 @@ class Api::V1::UsersController < ApplicationController
     end
   end
 
+  def update
+    user = User.find(update_params[:id])
+    if user.update(update_params)
+      render json: UserSerializer.new(user), status: 201
+    else
+      render json: {data: { error: "Please make sure to fill out all appropritate address fields with a valid address."}}, status: 422
+    end
+  end
+
   private
 
   def user_params
-    params.permit(:username, :first_name, :last_name, :address, :city, :zipcode)
+    params.permit(:id, :username, :first_name, :last_name, :address, :city, :zipcode)
+  end
+
+  def update_params
+    params.permit(:id, :address, :city, :zipcode)
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,14 @@ class User < ApplicationRecord
   validates :address, presence: true
   validates :city, presence: true
   validates :zipcode, presence: true
+
+  def latitude
+    coords = MapService.get_coords("#{address}, #{city}, #{zipcode}")
+    coords[:lat]
+  end
+
+  def longitude
+    coords = MapService.get_coords("#{address}, #{city}, #{zipcode}")
+    coords[:lng]
+  end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,6 +1,6 @@
 class UserSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :username, :first_name, :last_name, :address, :city, :zipcode
+  attributes :username, :first_name, :last_name, :address, :city, :zipcode, :lat, :long
   # attribute :username do |user|
   #   user.username
   # end
@@ -17,12 +17,12 @@ class UserSerializer
   #   user.address
   # end
   #
-  # attribute :city do |user|
-  #   user.city
-  # end
-  #
-  # attribute :zipcode do |user|
-  #   user.zipcode
-  # end
+  attribute :lat do |user|
+    user.latitude
+  end
+
+  attribute :long do |user|
+    user.longitude
+  end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :sessions, only: [:create, :destroy]
-      resources :users, only: [:create]
+      resources :users, only: [:create, :update]
       resources :trucks, only: [:index]
     end
   end

--- a/spec/requests/api/v1/users/create_user_spec.rb
+++ b/spec/requests/api/v1/users/create_user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "Users API" do
 
-  xit "can create a new user - happy path" do
+  it "can create a new user - happy path" do
     user_params = {
                     username: 'tsnieuwen',
                     first_name: 'Tommy',
@@ -11,11 +11,12 @@ describe "Users API" do
                     city: 'Vancouver',
                     zipcode: 'V5Z 1J8'
                     }
+    full_address = "#{user_params[:address]}, #{user_params[:city]}, #{user_params[:zipcode]}"
+    coords = MapService.get_coords(full_address)
+
 
     post "/api/v1/users", params: user_params
-
     user = JSON.parse(response.body, symbolize_names: true)
-
     expect(response).to be_successful
     expect(response.status).to eq(201)
     expect(user).to be_a(Hash)
@@ -24,16 +25,18 @@ describe "Users API" do
     expect(user[:data].keys).to eq([:id, :type, :attributes])
     expect(user[:data][:type]).to eq("user")
     expect(user[:data][:attributes]).to be_a(Hash)
-    expect(user[:data][:attributes].keys).to eq([:username, :first_name, :last_name, :address, :city, :zipcode])
+    expect(user[:data][:attributes].keys).to eq([:username, :first_name, :last_name, :address, :city, :zipcode, :lat, :long])
     expect(user[:data][:attributes][:username]).to eq(user_params[:username])
     expect(user[:data][:attributes][:first_name]).to eq(user_params[:first_name])
     expect(user[:data][:attributes][:last_name]).to eq(user_params[:last_name])
     expect(user[:data][:attributes][:address]).to eq(user_params[:address])
     expect(user[:data][:attributes][:city]).to eq(user_params[:city])
     expect(user[:data][:attributes][:zipcode]).to eq(user_params[:zipcode])
+    expect(user[:data][:attributes][:lat]).to eq(coords[:lat])
+    expect(user[:data][:attributes][:long]).to eq(coords[:lng])
   end
 
-  xit "can create a new user - sad path - no username" do
+  it "can create a new user - sad path - no username" do
     user_params = {
                     first_name: 'Tommy',
                     last_name: 'Pickles',
@@ -43,7 +46,6 @@ describe "Users API" do
                     }
 
     post "/api/v1/users", params: user_params
-
     body = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to_not be_successful
@@ -55,7 +57,7 @@ describe "Users API" do
     expect(body[:data][:error]).to eq("Please make sure all fields are filled in before registering. If error persists after filling out fields, username already exists.")
   end
 
-  xit "can create a new user - sad path - username already exists" do
+  it "can create a new user - sad path - username already exists" do
     user_params_existing = {
                     username: 'tsnieuwen',
                     first_name: 'Tommy',

--- a/spec/requests/api/v1/users/show_user_spec.rb
+++ b/spec/requests/api/v1/users/show_user_spec.rb
@@ -7,13 +7,14 @@ describe "Users API" do
                     username: 'tsnieuwen',
                     first_name: 'Tommy',
                     last_name: 'Pickles',
-                    address: '123 Broadway',
-                    city: 'Denver',
-                    zipcode: '12345'
+                    address: '898 W Broadway',
+                    city: 'Vancouver',
+                    zipcode: 'V5Z 1J8'
                     }
 
-    User.create(user_params_existing)
-
+    user = User.create(user_params_existing)
+    full_address = "#{user.address}, #{user.city}, #{user.zipcode}"
+    coords = MapService.get_coords(full_address)
     login_params = {username: 'tsnieuwen'}
 
     get "api/v1/users", params: login_params

--- a/spec/requests/api/v1/users/update_spec.rb
+++ b/spec/requests/api/v1/users/update_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+
+describe "Happy path update users API" do
+  before :each do
+    user_params = {
+      username: 'tsnieuwen',
+      first_name: 'Tommy',
+      last_name: 'Pickles',
+      address: '898 W Broadway',
+      city: 'Vancouver',
+      zipcode: 'V5Z 1J8'
+    }
+    @user = User.create(user_params)
+    @full_address = "#{user_params[:address]}, #{user_params[:city]}, #{user_params[:zipcode]}"
+    @coords = MapService.get_coords(@full_address)
+  end
+
+  it "can update an existing user - happy path" do
+    updated_user_params = {
+                    username: 'tsnieuwen',
+                    first_name: 'Tommy',
+                    last_name: 'Pickles',
+                    address: '433 Robson St',
+                    city: 'Vancouver',
+                    zipcode: 'V6B 6L9'
+                    }
+
+    updated_full_address = "#{updated_user_params[:address]}, #{updated_user_params[:city]}, #{updated_user_params[:zipcode]}"
+    updated_coords = MapService.get_coords(updated_full_address)
+    patch "/api/v1/users/#{@user.id}", params: updated_user_params
+    user = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(response.status).to eq(201)
+    expect(user).to be_a(Hash)
+    expect(user).to have_key(:data)
+    expect(user[:data]).to be_a(Hash)
+    expect(user[:data].keys).to eq([:id, :type, :attributes])
+    expect(user[:data][:type]).to eq("user")
+    expect(user[:data][:attributes]).to be_a(Hash)
+    expect(user[:data][:attributes].keys).to eq([:username, :first_name, :last_name, :address, :city, :zipcode, :lat, :long])
+    expect(user[:data][:attributes][:username]).to eq(updated_user_params[:username])
+    expect(user[:data][:attributes][:first_name]).to eq(updated_user_params[:first_name])
+    expect(user[:data][:attributes][:last_name]).to eq(updated_user_params[:last_name])
+    expect(user[:data][:attributes][:address]).to eq(updated_user_params[:address])
+    expect(user[:data][:attributes][:city]).to eq(updated_user_params[:city])
+    expect(user[:data][:attributes][:zipcode]).to eq(updated_user_params[:zipcode])
+    expect(user[:data][:attributes][:lat]).to eq(updated_coords[:lat])
+    expect(user[:data][:attributes][:long]).to eq(updated_coords[:lng])
+  end
+
+  describe "Sad path " do
+    it "can update an existing user - sad path - no address" do
+      updated_user_params = {
+                      username: 'tsnieuwen',
+                      first_name: 'Tommy',
+                      last_name: 'Pickles',
+                      address: '',
+                      city: 'Vancouver',
+                      zipcode: 'V6B 6L9'
+                      }
+
+      patch "/api/v1/users/#{@user.id}", params: updated_user_params
+      user = JSON.parse(response.body, symbolize_names: true)
+      expect(response).to_not be_successful
+      expect(response.status).to eq(422)
+      expect(user).to be_a(Hash)
+      expect(user).to have_key(:data)
+      expect(user[:data]).to be_a(Hash)
+      expect(user[:data].keys).to eq([:error])
+      expect(user[:data][:error]).to eq("Please make sure to fill out all appropritate address fields with a valid address.")
+    end
+
+    it "can create a new user - sad path - no city" do
+      updated_user_params = {
+                      username: 'tsnieuwen',
+                      first_name: 'Tommy',
+                      last_name: 'Pickles',
+                      address: '433 Robson St',
+                      city: '',
+                      zipcode: 'V6B 6L9'
+                      }
+
+      patch "/api/v1/users/#{@user.id}", params: updated_user_params
+      user = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(422)
+      expect(user).to be_a(Hash)
+      expect(user).to have_key(:data)
+      expect(user[:data]).to be_a(Hash)
+      expect(user[:data].keys).to eq([:error])
+      expect(user[:data][:error]).to eq("Please make sure to fill out all appropritate address fields with a valid address.")
+    end
+
+    it "can create a new user - sad path - no zipcode" do
+      updated_user_params = {
+                      username: 'tsnieuwen',
+                      first_name: 'Tommy',
+                      last_name: 'Pickles',
+                      address: '433 Robson St',
+                      city: 'Vancouver',
+                      zipcode: ''
+                      }
+
+      patch "/api/v1/users/#{@user.id}", params: updated_user_params
+      user = JSON.parse(response.body, symbolize_names: true)
+      expect(response).to_not be_successful
+      expect(response.status).to eq(422)
+      expect(user).to be_a(Hash)
+      expect(user).to have_key(:data)
+      expect(user[:data]).to be_a(Hash)
+      expect(user[:data].keys).to eq([:error])
+      expect(user[:data][:error]).to eq("Please make sure to fill out all appropritate address fields with a valid address.")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds two class methods on the user model for getting latitude and longitude. The methods get called in the user serializer so the return data is available for the FE to render the users location. 